### PR TITLE
Restrict rich-markdown-editor features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react-i18next": "^11.10.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
-        "rich-markdown-editor": "^11.9.1",
+        "rich-markdown-editor": "github:outline/rich-markdown-editor#pull/438/head",
         "showdown": "^1.9.1",
         "web-vitals": "^1.1.2"
       }
@@ -17613,9 +17613,9 @@
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "node_modules/rich-markdown-editor": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/rich-markdown-editor/-/rich-markdown-editor-11.9.1.tgz",
-      "integrity": "sha512-o5+SMSExhT6hvgcEU/dbW648tTA22uqHjXcpN179BKP1JHKZMg90VwBiqFCLm+5uEHe3pCOSi2K5GAOD1yG9HQ==",
+      "version": "11.7.0",
+      "resolved": "git+ssh://git@github.com/outline/rich-markdown-editor.git#60d2145aebe3d019946464294d386fdb4267cda5",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "copy-to-clipboard": "^3.0.8",
         "lodash": "^4.17.11",
@@ -17634,7 +17634,7 @@
         "prosemirror-tables": "^1.1.1",
         "prosemirror-transform": "1.2.5",
         "prosemirror-utils": "^0.9.6",
-        "prosemirror-view": "^1.18.4",
+        "prosemirror-view": "^1.17.6",
         "react-medium-image-zoom": "^3.1.3",
         "react-portal": "^4.2.1",
         "refractor": "^3.3.1",
@@ -36384,9 +36384,8 @@
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rich-markdown-editor": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/rich-markdown-editor/-/rich-markdown-editor-11.9.1.tgz",
-      "integrity": "sha512-o5+SMSExhT6hvgcEU/dbW648tTA22uqHjXcpN179BKP1JHKZMg90VwBiqFCLm+5uEHe3pCOSi2K5GAOD1yG9HQ==",
+      "version": "git+ssh://git@github.com/outline/rich-markdown-editor.git#60d2145aebe3d019946464294d386fdb4267cda5",
+      "from": "rich-markdown-editor@outline/rich-markdown-editor#pull/438/head",
       "requires": {
         "copy-to-clipboard": "^3.0.8",
         "lodash": "^4.17.11",
@@ -36405,7 +36404,7 @@
         "prosemirror-tables": "^1.1.1",
         "prosemirror-transform": "1.2.5",
         "prosemirror-utils": "^0.9.6",
-        "prosemirror-view": "^1.18.4",
+        "prosemirror-view": "^1.17.6",
         "react-medium-image-zoom": "^3.1.3",
         "react-portal": "^4.2.1",
         "refractor": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-i18next": "^11.10.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
-    "rich-markdown-editor": "^11.9.1",
+    "rich-markdown-editor": "github:outline/rich-markdown-editor#pull/438/head",
     "showdown": "^1.9.1",
     "web-vitals": "^1.1.2"
   },

--- a/src/components/AddContent/index.js
+++ b/src/components/AddContent/index.js
@@ -124,6 +124,7 @@ import showdown from 'showdown'
                      <Editor
                      dark={window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches}
                      defaultValue={cms && `![${cms.info.name}](${matrixClient.mxcUrlToHttp(cms.url)})`}
+                     disableExtensions={['blockmenu', /*'image',*/ 'embed', 'table', 'tr', 'th', 'td', 'bullet_list', 'ordered_list', 'checkbox_item', 'checkbox_list', 'container_notice', 'blockquote', 'heading', 'hr', 'highlight']}
                       readOnly={true}
                       key={index}
                     />
@@ -139,6 +140,7 @@ import showdown from 'showdown'
                                         <Editor
                       dark={window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches}
                       defaultValue={cms?.body}
+                      disableExtensions={['blockmenu', 'image', 'embed', 'table', 'tr', 'th', 'td', 'bullet_list', 'ordered_list', 'checkbox_item', 'checkbox_list', 'container_notice', 'blockquote', 'heading', 'hr', 'highlight']}
                       placeholder={json.type}
                           readOnly={readOnly}
                           onSave={({ done }) => { if (localStorage.getItem(block.room_id) !== null && cms !== undefined && string2hash(cms.body) !== string2hash(localStorage.getItem(block.room_id))) {


### PR DESCRIPTION
This will make us basically use the Pull Request outlined in https://github.com/outline/rich-markdown-editor/pull/438.
Because of that (basically using a GitHub Pull Request as a `npm` dependency) you to have `yarn` installed on your computer. I know, weird. Also erst `brew install yarn` und dann geht auch `npm install` wieder.

![image](https://user-images.githubusercontent.com/706419/121938714-717a9680-cd4c-11eb-89cf-8d9d6ddad5fb.png)
