### PR TITLE
Canonical alias

### DIFF
--- a/src/components/PublishProject/index.js
+++ b/src/components/PublishProject/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Loading } from '../loading'
 import { useTranslation } from 'react-i18next'
 import Matrix from '../../Matrix'
+import config from '../../config.json'
 
 const PublishProject = ({ disabled, space, published, hasContext, metaEvent }) => {
   const { t } = useTranslation('publish')
@@ -29,6 +30,29 @@ const PublishProject = ({ disabled, space, published, hasContext, metaEvent }) =
   }, [matrixClient, metaEvent, published, space.room_id])
 
   const onChangeVisibility = async (publishState) => {
+    if (config.medienhaus.createCanonicalAliasOnPublish) {
+      // as of now spaces need a canonical alias and be listed in the room direcotry in order to be joinable via federation
+      // we create the alias with the title of the item seperated by dashes and in lower case.
+      // @TODO sanitise for special characters which might be allowed in room name but not for the alias
+      const alias = '#' + space.name.replace(/\s+/g, '-').toLowerCase() + '-' + localStorage.getItem('mx_user_id').substring(1)
+      if (publishState === 'public') {
+        const createAlias = await matrixClient.createAlias(alias, space.room_id)
+          .catch((e) => {
+            setUserFeedback(e.data.error)
+            setTimeout(() => setUserFeedback(''), 3000)
+          })
+        // if setting the alias fails we return out of the function
+        if (!createAlias) return
+      }
+      const sendEvent = await matrixClient.sendStateEvent(space.room_id, 'm.room.canonical_alias', { alias: alias })
+      // if setting the alias fails we return out of the function
+      if (!sendEvent.event_id) return
+      // @TODO Not sure if alias should be deleted when setting an item back to draft.
+      // else {
+      //   const deleteAlias = await matrixClient.deleteAlias('#' + space.name.replace(/\s+/g, '-').toLowerCase() + '-' + localStorage.getItem('mx_user_id').substring(1))
+      // }
+    }
+
     setVisibility(publishState)
     const hierarchy = await matrixClient.getRoomHierarchy(space.room_id, 50, 1)
     const joinRules = {

--- a/src/routes/content/deleteProject.js
+++ b/src/routes/content/deleteProject.js
@@ -1,4 +1,5 @@
 import Matrix from '../../Matrix'
+import config from '../../config.json'
 
 const deleteProject = async (roomId) => {
   const matrixClient = Matrix.getMatrixClient()
@@ -26,7 +27,14 @@ const deleteProject = async (roomId) => {
       })
       await matrixClient.leave(space.room_id).catch(console.log)
     })
+    // if the room had a canonical alias we delete it and remove it from the room directory
+    if (config.medienhaus.createCanonicalAliasOnPublish) {
+      await matrixClient.setRoomDirectoryVisibility(roomId, 'private')
+        .catch(console.debug)
+      await matrixClient.deleteAlias('#' + space.rooms[0].name.replace(/\s+/g, '-').toLowerCase() + '-' + localStorage.getItem('mx_user_id').substring(1))
+    }
     await matrixClient.leave(roomId).catch(console.log)
+
     log = 'successfully deleted ' + roomId
   } catch (err) {
     log = err


### PR DESCRIPTION
Add canonical alias when publishing an item. 
As of now it looks like this is needed to be able to join a space from a different server.
