### PR TITLE
Refactor video block in gutenberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ Define which sites should be visible and which functions should be available in 
   - `showRoot`: if enabled the root of all contexts is displayed in the manage context dropdown.
   - `treeDepth`: depth of the tree shown after selecting a context. defaults to 1.
 
+### `video`
+
+the video object defines which video platforms are supported by the cms:
+There is built in support for Vimeo and YouTube, which needs to be activated.
+
+```
+ "video": {
+            "youtube": true,
+            "vimeo": true,
+            "custom": {
+              "label": "Peerube",
+              "baseUrl": "https://peertube.server.com/w/",
+              "iframeUrl": "https://peertube.server.com/embed/",
+              "uploadUrl": ""https://stream.udk-berlin.de/videos/upload"
+            }
+        }
+```
+<aside>
+‼️ The `baseUrl` of your custom platform needs to be the exact url which is going to be replaced by `iframeUrl` for the iframe preview.
+</aside>
+
 ### `usersToInviteToNewContexts`
 
 All users specified in this array are automatically invited to new context spaces if they are created through the manage context UI in /manage and promoted to power level 50.

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ There is built in support for Vimeo and YouTube, which needs to be activated.
             }
         }
 ```
-<aside>
+
 ‼️ The `baseUrl` of your custom platform needs to be the exact url which is going to be replaced by `iframeUrl` for the iframe preview.
-</aside>
+
 
 ### `usersToInviteToNewContexts`
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ There is built in support for Vimeo and YouTube, which needs to be activated.
             "youtube": true,
             "vimeo": true,
             "custom": {
-              "label": "Peerube",
+              "label": "Peertube",
               "baseUrl": "https://peertube.server.com/w/",
               "iframeUrl": "https://peertube.server.com/embed/",
               "uploadUrl": ""https://stream.udk-berlin.de/videos/upload"

--- a/src/routes/gutenberg/blocks/video.js
+++ b/src/routes/gutenberg/blocks/video.js
@@ -5,6 +5,7 @@ import { Trans } from 'react-i18next'
 import { useState } from '@wordpress/element'
 import { View } from '@wordpress/primitives'
 import i18n from 'i18next'
+import config from '../../../config.json'
 
 const t = i18n.getFixedT(null, 'gutenberg')
 
@@ -37,37 +38,89 @@ const video = {
     }
 
     const isValidUrl = (url) => {
-      return url && url.startsWith && url.startsWith('https://stream.udk-berlin.de/')
+      // @TODO validation needs to be more  (check https etc.)
+      if (config.medienhaus.video.youtube && url?.includes('youtu')) return true
+      if (config.medienhaus.video.vimeo && url?.includes('vimeo.com')) return true
+      return url && url.startsWith && url.startsWith(config.medienhaus.video?.custom?.baseUrl)
     }
 
     if (isValidUrl(content)) {
+      if (config.medienhaus.video) {
+        return (
+          <View {...blockProps}>
+            <iframe
+              src={`${config.medienhaus.video.custom.iframeUrl}${content.replace(config.medienhaus.video.custom.baseUrl, '')}`}
+              frameBorder="0"
+              title={content}
+              sandbox="allow-same-origin allow-scripts"
+              allowFullScreen="allowfullscreen"
+              width="560"
+              height="315"
+              style={{ width: '100%', aspectRatio: '16 / 9', border: 'calc(var(--margin) * 0.2) solid var(--color-fg)' }}
+            />
+          </View>
+        )
+      }
+
+      if (config.medienhaus.video.youtube && content?.includes('youtu')) {
+        return (
+          <View {...blockProps}>
+            <iframe
+              src={`https://www.youtube.com/embed/${content.replace(content.includes('/watch?v=') ? 'https://www.youtube.com/watch?v=' : 'https://youtu.be/', '')}`}
+              frameBorder="0"
+              title={content}
+              sandbox="allow-same-origin allow-scripts"
+              allowFullScreen="allowfullscreen"
+              width="560"
+              height="315"
+              style={{ width: '100%', aspectRatio: '16 / 9', border: 'calc(var(--margin) * 0.2) solid var(--color-fg)' }}
+            />
+          </View>
+        )
+      }
+      if (config.medienhaus.video.vimeo && content?.includes('vimeo.com/')) {
+        return (
+          <View {...blockProps}>
+            <iframe
+              src={`https://player.vimeo.com/video/${content.replace('https://vimeo.com/', '')}`}
+              frameBorder="0"
+              title={content}
+              sandbox="allow-same-origin allow-scripts"
+              allowFullScreen="allowfullscreen"
+              width="560"
+              height="315"
+              style={{ width: '100%', aspectRatio: '16 / 9', border: 'calc(var(--margin) * 0.2) solid var(--color-fg)' }}
+            />
+          </View>
+        )
+      }
+    }
+
+    // in case content is parsed but the platform not supported:
+    if (content) {
       return (
         <View {...blockProps}>
-          <iframe
-            src={`https://stream.udk-berlin.de/videos/embed/${content.replace('https://stream.udk-berlin.de/w/', '')}`}
-            frameBorder="0"
-            title={content}
-            sandbox="allow-same-origin allow-scripts"
-            allowFullScreen="allowfullscreen"
-            width="560"
-            height="315"
-            style={{ width: '100%', aspectRatio: '16 / 9', border: 'calc(var(--margin) * 0.2) solid var(--color-fg)' }}
-          />
+          <p><em>{t('No preview available for')}:</em></p>
+          <a href={content} target="_blank" rel="external nofollow noopener noreferrer">{content}</a>
         </View>
       )
     }
-
     return (
       <View {...blockProps}>
         <form onSubmit={onSubmit}>
           <input
             type="url"
             value={urlInput}
-            placeholder="https://stream.udk-berlin.de/…"
+            placeholder={(config.medienhaus.video?.custom?.baseUrl || 'https://') + '…'}
             onChange={(e) => setUrlInput(e.target.value)}
           />
           <button type="submit" disabled={!isValidUrl(urlInput)}>{t('Embed Video')}</button>
-          <p>↳ <Trans t={t} i18nKey="linkToVideo">You can upload videos via <a href="https://stream.udk-berlin.de/videos/upload" rel="external nofollow noopener noreferrer" target="_blank">udk/stream</a></Trans></p>
+          <p>↳
+            {config.medienhaus.video?.custom && <Trans t={t} i18nKey="linkToVideo">You can upload videos via <a href={config.medienhaus.video.custom.uploadUrl || config.medienhaus.video.custom.baseUrl} rel="external nofollow noopener noreferrer" target="_blank">{
+              config.medienhaus.video.custom.label
+            }</a>
+            </Trans>}
+          </p>
         </form>
       </View>
     )

--- a/src/routes/gutenberg/blocks/video.js
+++ b/src/routes/gutenberg/blocks/video.js
@@ -39,8 +39,9 @@ const video = {
 
     const isValidUrl = (url) => {
       // @TODO validation needs to be more  (check https etc.)
-      if (config.medienhaus.video.youtube && url?.includes('youtu')) return true
-      if (config.medienhaus.video.vimeo && url?.includes('vimeo.com')) return true
+      if (!config.medienhaus.video) return true
+      if (config.medienhaus.video?.youtube && url?.includes('youtu')) return true
+      if (config.medienhaus.video?.vimeo && url?.includes('vimeo.com')) return true
       return url && url.startsWith && url.startsWith(config.medienhaus.video?.custom?.baseUrl)
     }
 
@@ -49,7 +50,7 @@ const video = {
         return (
           <View {...blockProps}>
             <iframe
-              src={`${config.medienhaus.video.custom.iframeUrl}${content.replace(config.medienhaus.video.custom.baseUrl, '')}`}
+              src={`${config.medienhaus.video?.custom?.iframeUrl}${content.replace(config.medienhaus.video.custom.baseUrl, '')}`}
               frameBorder="0"
               title={content}
               sandbox="allow-same-origin allow-scripts"
@@ -62,7 +63,7 @@ const video = {
         )
       }
 
-      if (config.medienhaus.video.youtube && content?.includes('youtu')) {
+      if (config.medienhaus.video?.youtube && content?.includes('youtu')) {
         return (
           <View {...blockProps}>
             <iframe
@@ -78,7 +79,7 @@ const video = {
           </View>
         )
       }
-      if (config.medienhaus.video.vimeo && content?.includes('vimeo.com/')) {
+      if (config.medienhaus.video?.vimeo && content?.includes('vimeo.com/')) {
         return (
           <View {...blockProps}>
             <iframe


### PR DESCRIPTION
Refactors the video block for the gutenberg editor. 
Adds the video platform to the config file and built-in support for Vimeo and Youtube (opt-in).

The following object needs to be added to the config

```
 "video": {
            "youtube": true,
            "vimeo": true,
            "custom": {
              "label": "Peertube",
              "baseUrl": "https://peertube.server.com/w/",
              "iframeUrl": "https://peertube.server.com/embed/",
              "uploadUrl": ""https://stream.udk-berlin.de/videos/upload"
            }
        }
```

if no video object is supplied, any video can be uploaded but the preview is disabled and replaced with a standard link.
