### PR TITLE
list view function for /content

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -897,6 +897,44 @@ button>.loading {
   visibility: hidden;
 }
 
+.contentHeader {
+  display: grid;
+  grid-gap: var(--margin);
+  grid-template-columns: 4fr 1fr;
+  margin-bottom: calc(var(--margin) * 2);
+}
+
+.contentHeader > button {
+  background: none;
+  border: none;
+  color: white;
+  padding: 0;
+  margin: 0;
+  text-align: right;
+  height: 1rem;
+  line-height: 1rem;
+}
+
+.projectSmall {
+  display: grid;
+  grid-gap: var(--margin);
+  grid-template-columns: 4fr 1fr;
+}
+
+.projectSmall > div {
+  grid-template-columns: 1fr 1fr;
+  display: grid;
+}
+
+.projectSmall > div > button {
+  font-size: .75rem;
+  padding: 0;
+  height: 1rem;
+  background: none;
+  border: none;
+  text-align: right;
+}
+
 .project {
   display: grid;
   grid-gap: var(--margin);

--- a/src/assets/locales/de/content.json
+++ b/src/assets/locales/de/content.json
@@ -70,5 +70,7 @@
   "Last saved at": "Zuletzt gespeichert:",
   "You are already part of this project 🥳": "Du bis bereits Teil dieses Projektes 🥳",
   "Date and Venue": "Datum und Veranstaltungsort",
-  "SAVE CHANGES": "ÄNDERUNGEN SPEICHERN"
+  "SAVE CHANGES": "ÄNDERUNGEN SPEICHERN",
+  "grid": "Raster",
+  "list": "Liste"
 }

--- a/src/routes/content/Projects/index.js
+++ b/src/routes/content/Projects/index.js
@@ -6,33 +6,49 @@ import DeleteProjectButton from './DeleteProjectButton'
 
 import config from '../../../config.json'
 
-const Content = ({ space, metaEvent, visibility, index, removeProject }) => {
+const Content = ({ space, metaEvent, visibility, index, removeProject, displayStyle }) => {
   const history = useHistory()
   const { t } = useTranslation('content')
   const matrixClient = Matrix.getMatrixClient()
   const [showDeleteComponent, setShowDeleteComponent] = useState(false)
 
   return (
+
     <>
-      <div className="project">
-        <h3 className="above">{space.name}
-          <span style={{ color: 'gray' }}> {metaEvent?.published.toUpperCase()}</span>
-          {config.medienhaus?.item &&
-            <span style={{ color: 'gray', float: 'right' }}>{config.medienhaus?.item ? config.medienhaus?.item[metaEvent.template]?.label.toUpperCase() : metaEvent.type.toUpperCase()}</span>}
-        </h3>
-        <figure className="left">
-          {space.avatar_url && <img src={matrixClient.mxcUrlToHttp(space.avatar_url)} alt="project-visual-key" />}
-        </figure>
-        <div className="center">
-          {/* @TODO grab description based on selected cms language */}
-          <p>{space.topic || '❗️' + t('Please add a short description.')}</p>
-        </div>
-        <button disabled={showDeleteComponent} onClick={() => history.push(`/create/${space.room_id}`)}>{t('EDIT')}</button>
-        <button disabled={showDeleteComponent} onClick={() => setShowDeleteComponent(true)}>{t('DELETE')}</button>
-      </div>
-      {showDeleteComponent &&
-        <DeleteProjectButton roomId={space.room_id} name={space.name} index={index} toggleDeleteButton={() => setShowDeleteComponent(false)} removeProject={removeProject} />}
+      {displayStyle === 'grid' &&
+        <>
+          <div className="project">
+            <h3 className="above">{space.name}
+              <span style={{ color: 'gray' }}> {metaEvent?.published.toUpperCase()}</span>
+              {config.medienhaus?.item &&
+                <span style={{ color: 'gray', float: 'right' }}>{config.medienhaus?.item ? config.medienhaus?.item[metaEvent.template]?.label.toUpperCase() : metaEvent.type.toUpperCase()}</span>}
+            </h3>
+            <figure className="left">
+              {space.avatar_url && <img src={matrixClient.mxcUrlToHttp(space.avatar_url)} alt="project-visual-key" />}
+            </figure>
+            <div className="center">
+              {/* @TODO grab description based on selected cms language */}
+              <p>{space.topic || '❗️' + t('Please add a short description.')}</p>
+            </div>
+            <button disabled={showDeleteComponent} onClick={() => history.push(`/create/${space.room_id}`)}>{t('EDIT')}</button>
+            <button disabled={showDeleteComponent} onClick={() => setShowDeleteComponent(true)}>{t('DELETE')}</button>
+          </div>
+
+          {showDeleteComponent &&
+            <DeleteProjectButton roomId={space.room_id} name={space.name} index={index} toggleDeleteButton={() => setShowDeleteComponent(false)} removeProject={removeProject} />}
+        </>}
+      {displayStyle === 'list' &&
+        <>
+          <div className="projectSmall">
+            <h3 className="above">{space.name}</h3>
+            <div>
+              <button disabled={showDeleteComponent} onClick={() => history.push(`/create/${space.room_id}`)}>✏️</button>
+              <button disabled={showDeleteComponent} onClick={() => setShowDeleteComponent(true)}>🗑️</button>
+            </div>
+          </div>
+        </>}
     </>
+
   )
 }
 


### PR DESCRIPTION
A 'list' view as part of the `/content` route which can be toggled between the default 'grid' view as well as a new more compact 'list' view. In this view the short description of each item is not displayed anymore as well as the buttons got changed into emojis instead of text. As well as the items got structured based on their templates to get a better overview about them. This new feature got not written as a generalized component.