### PR TITLE
fix for infinity loading gutenberg

### DIFF
--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -533,7 +533,7 @@ const Create = () => {
     const fetchContentsForGutenberg = async () => {
       const contents = []
       for (const block of blocks) {
-        const fetchMessage = await matrixClient.http.authedRequest('GET', `/rooms/${block.room_id}/messages`, { limit: 1, dir: 'b', filter: JSON.stringify({ types: ['m.room.message'] }) }, {})
+        const fetchMessage = await matrixClient.http.authedRequest('GET', `/rooms/${block.room_id}/messages`, { limit: 1, dir: 'b', filter: JSON.stringify({ types: ['m.room.message'] }) })
         const message = _.isEmpty(fetchMessage.chunk) ? null : fetchMessage.chunk[0].content
 
         if (message) {


### PR DESCRIPTION
the function tried to send an empty object `{}` as a body payload, which is not possible via GET to have any body payload. therefore getting rid of it and keeping this parameter undefined will fix the issue.