### PR TITLE
adding support for configurable description lenght

### DIFF
--- a/src/config.extended.example.json
+++ b/src/config.extended.example.json
@@ -58,6 +58,9 @@
         "name": true,
         "mail": true
       },
+      "limits": {
+        "descriptionMaxCharacters": 500
+      },
       "moderate": {
         "invite": true,
         "rightsManagement": true,

--- a/src/routes/create/ProjectDescription/index.js
+++ b/src/routes/create/ProjectDescription/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import TextareaAutosize from 'react-textarea-autosize'
+import config from '../../../config.json'
 
 const ProjectDescription = ({ description: intro, callback }) => {
   const { t } = useTranslation('content')
@@ -8,7 +9,7 @@ const ProjectDescription = ({ description: intro, callback }) => {
   const [backupDescription, setBackupDescription] = useState()
 
   const onSave = async () => {
-    if (description.length > 500) return
+    if (description.length > (config?.medienhaus?.limits?.descriptionMaxCharacters ? config?.medienhaus?.limits?.descriptionMaxCharacters : 500)) return
     if (description) {
       await callback(description)
     } else {
@@ -33,7 +34,7 @@ const ProjectDescription = ({ description: intro, callback }) => {
           onBlur={() => onSave()}
         />
         <div className="maxlength">
-          <span>{description.length + '/500'}</span>
+          <span>{description.length + '/' + (config?.medienhaus?.limits?.descriptionMaxCharacters ? config?.medienhaus?.limits?.descriptionMaxCharacters : 500)}</span>
         </div>
       </div>
     </>

--- a/src/routes/moderate/components/ManageContexts.js
+++ b/src/routes/moderate/components/ManageContexts.js
@@ -277,7 +277,7 @@ const ManageContexts = ({ matrixClient, moderationRooms: incomingModerationRooms
   }
 
   const onSaveDescription = async (description) => {
-    if (description.length > 500) return
+    if (description.length > (config?.medienhaus?.limits?.descriptionMaxCharacters ? config?.medienhaus?.limits?.descriptionMaxCharacters : 500)) return
     await matrixClient.setRoomTopic(selectedContext, description).catch(console.log)
     if (config.medienhaus.api) triggerApiUpdate(selectedContext)
     const context = findValueWithDeepDash(selectedContext)
@@ -485,7 +485,7 @@ const ManageContexts = ({ matrixClient, moderationRooms: incomingModerationRooms
               <summary>
                 <h3>{t('Change Description')}</h3>
               </summary>
-              <TextareaAutoSizeMaxLength description={description} setDescription={setDescription} onSaveDescription={onSaveDescription} />
+              <TextareaAutoSizeMaxLength description={description} setDescription={setDescription} onSaveDescription={onSaveDescription} maxLength={(config?.medienhaus?.limits?.descriptionMaxCharacters ? config?.medienhaus?.limits?.descriptionMaxCharacters : 500)} />
             </Details>
             <Details>
 


### PR DESCRIPTION
getting rid of the 500 char limit, which is not matrix based for topics. it is now possible to define a max char limit for the length of a description. this effects the 'create' route as well as the 'moderate' route as it is possible to add descriptions to contexts as well as to items. this config key is optional so if it is not defined it will fallback to 500 chars.