### PR TITLE
fix for media upload in gutenberg

### DIFF
--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -400,7 +400,8 @@ const Create = () => {
           let uploadedImage = await matrixClient.uploadContent(block.attributes.file, { name: block.attributes.file.name })
           await matrixClient.sendImageMessage(
             roomId,
-            uploadedImage,
+            null,
+            uploadedImage?.content_uri,
             {
               mimetype: block.attributes.file.type,
               size: block.attributes.file.size,
@@ -431,7 +432,7 @@ const Create = () => {
               alt: block.attributes.alttext
             },
             msgtype: 'm.audio',
-            url: uploadedAudio
+            url: uploadedAudio?.content_uri
           })
           break
         case 'medienhaus/file':
@@ -450,7 +451,7 @@ const Create = () => {
               alt: block.attributes.alttext
             },
             msgtype: 'm.file',
-            url: uploadedFile
+            url: uploadedFile?.content_uri
           })
           break
         default:


### PR DESCRIPTION
there were two bugs which created the problem to use media blocks in the gutenberg editor. on the one hand it was not possible to upload images at all anymore. this was based on the change of parameters of the 'sendImageMessage' function of the matrix-js-sdk which resulted in a infinity loop after trying to save the changes. on the other hand an additional problem bricked all valid media uploads. they were still uploaded but not possible to display neither in element nor in the cms. this problem occured with the change of the return of the 'uploadContent' function of the matrix-js-sdk, which now returns an object with the key 'content_uri' instead of a string. a bugfix for this problem was implemented in the main branch before already for the thumbnail upload.