### PR TITLE
Implement "Request Access to Spaces" Feature

### DIFF
--- a/src/Matrix.js
+++ b/src/Matrix.js
@@ -123,6 +123,8 @@ class Matrix {
     await this.matrixClient.sendStateEvent(room.room_id, 'dev.medienhaus.meta', medienhausMetaEvent)
     return room
   }
+
+  knockOnMatrixRoom = (roomId) => this.matrixClient.http.authedRequest('POST', `/knock/${roomId}`, undefined, {})
 }
 
 export default new Matrix()

--- a/src/components/nav/index.js
+++ b/src/components/nav/index.js
@@ -63,7 +63,7 @@ const Nav = () => {
         })
         setKnockAmount(pendingKnocks.length)
       }
-      getAmountOfPendingKnocks()
+      config.medienhaus?.sites?.moderate?.accept && getAmountOfPendingKnocks()
     }
 
     return () => {

--- a/src/helpers/joinRoomIfKnocked.js
+++ b/src/helpers/joinRoomIfKnocked.js
@@ -1,0 +1,31 @@
+import Matrix from '../Matrix'
+
+/**
+ * This function checks if the previous membership state was 'knock' and if so, it attempts to join the room and alerts the user accordingly.
+ * @async
+ * @param {(string|Object)} roomOrSpaceId - The room ID or room object.
+ * @param {Object} event - The state event of the room.
+ * @returns {Promise<{room_id: string, message: string} | null>} A promise that resolves to an object with room_id and message properties if the membership conditions are met, and null otherwise.
+ * @throws Will throw an error if the join room request fails.
+ */
+export const joinRoomIfKnock = async (roomOrSpaceId, event) => {
+  if (!event) return null
+
+  // Check if roomOrSpaceId is a string, if so, it's a spaceId and we need to get the room
+  const room = typeof roomOrSpaceId === 'string' ? await Matrix.matrixClient.getRoom(roomOrSpaceId) : roomOrSpaceId
+  // Get the current and previous membership status
+  const membership = event?.content?.membership
+  const prevMembership = event?.prev_content?.membership || event.unsigned?.prev_content?.membership
+  // If the current membership is 'invite' and the previous membership was 'knock', join the room
+  if (membership === 'invite' && prevMembership === 'knock') {
+    try {
+      await Matrix.matrixClient.joinRoom(roomOrSpaceId)
+      return { room_id: roomOrSpaceId, message: `You have been added to the following context: ${room.name}` }
+    } catch (error) {
+      console.error(`Failed to join room: ${error}`)
+      throw error
+    }
+  }
+  // otherwise, return null
+  return null
+}

--- a/src/helpers/matrixClientEventHandlers.js
+++ b/src/helpers/matrixClientEventHandlers.js
@@ -1,0 +1,15 @@
+import Matrix from '../Matrix'
+import { joinRoomIfKnock } from './joinRoomIfKnocked'
+
+// Function to handle 'RoomMember.membership' events
+export const handleMembershipEvent = async (event, member) => {
+  // only listen to events for the current user
+  if (member.userId !== Matrix.getMatrixClient().getUserId()) return
+  const autoJoinRoom = await joinRoomIfKnock(event.event.room_id, event.event)
+    .catch(error => {
+      console.log(error)
+      alert(`The following error occurred: ${error.data?.error}`)
+    })
+  // if a room was joined, and the user therefore has access to the room, we alert the user
+  if (autoJoinRoom) alert(autoJoinRoom.message)
+}

--- a/src/routes/content/index.js
+++ b/src/routes/content/index.js
@@ -34,8 +34,11 @@ const Overview = () => {
       // get current membership
       const membership = event.content.membership
       if (membership === 'invite' && event.unsigned?.prev_content?.membership === 'knock') {
-        console.log('joining room')
-        await matrixClient.joinRoom(room.roomId).catch(console.log)
+        await matrixClient.joinRoom(room.roomId).catch(error => {
+          console.error(error)
+          alert(t('The following error occurred: {{error}}', { error: error.data?.error }))
+        })
+        alert(t('You have been added to the following context: {{roomName}}', { roomName: room.name }))
       }
 
       if (!metaEvent.template || !item.includes(metaEvent.template)) return

--- a/src/routes/content/index.js
+++ b/src/routes/content/index.js
@@ -11,7 +11,6 @@ import deleteProject from './deleteProject'
 
 import config from '../../config.json'
 import * as _ from 'lodash'
-import { joinRoomIfKnock } from '../../helpers/joinRoomIfKnocked'
 
 const Overview = () => {
   const { t } = useTranslation('content')
@@ -28,22 +27,9 @@ const Overview = () => {
       // Ignore if this is not an "item"
       const metaEvent = await matrixClient.getStateEvent(room.roomId, 'dev.medienhaus.meta').catch(() => {})
       // if no meta event is found, we don't want to display the room
-      if (!metaEvent) return
+      if (!metaEvent || !metaEvent.template || !item.includes(metaEvent.template)) return
 
-      // see if the previous membership state of the room was 'knock' and if so, we want to join the room
       const event = _.find(room.currentState.getMembers(), { userId: matrixClient.getUserId() }).events.member.event
-
-      // Check if there are any rooms where a user has previously requested access (knocked) and has now been granted permission to join.
-      const autoJoinRoom = await joinRoomIfKnock(room.roomId, event)
-        .catch(error => {
-          console.log(error)
-          alert(t('The following error occurred: {{error}}', { error: error.data?.error }))
-        })
-
-      // if a room was joined, and the user therefore has access to the room, we alert the user
-      if (autoJoinRoom) alert(t(autoJoinRoom.message))
-      if (!metaEvent.template || !item.includes(metaEvent.template)) return
-
       const membership = event.content.membership
       // Ignore if this is not an invitation
       if (membership !== 'invite') return

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -166,7 +166,22 @@ const Category = ({ projectSpace, onChange, parent }) => {
       delete projectSpaceMetaEvent.context
       await matrixClient.sendStateEvent(projectSpace, 'dev.medienhaus.meta', projectSpaceMetaEvent).catch(console.log)
     }
+    console.log('contextObject', contextObject)
+    if (!contextObject.membership) {
+      // if there is no membership (most likely because the contextObject came from the api) we need to check if the user is already a member of the context
 
+      // first we check if the user is already a member of the context
+      const membership = matrixClient.getRoom(contextSpace)?.getMyMembership()
+      console.log('membership', membership)
+      contextObject.membership = membership
+      // we check to see if the join rule of the context is 'knock' or 'knock_restricted'
+      const joinRuleEvent = await Matrix.getMatrixClient().getStateEvent(contextSpace, 'm.room.join_rules')
+      console.log('joinRuleEvent', joinRuleEvent)
+      if (joinRuleEvent?.join_rule !== 'knock' || joinRuleEvent.join_rule !== 'knock_restricted') return
+      contextObject.joinRule = joinRuleEvent.join_rule
+      const memberEvent = matrixClient.getRoom(contextSpace)
+      console.log('memberEvent', memberEvent)
+    }
     // If this project was in a different context previously we should try to take it out of the old context
 
     // if (currentContext && currentContext !== contextSpace) await Matrix.removeSpaceChild(currentContext, projectSpace).catch(console.log)

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -185,6 +185,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
           const knock = await Matrix.knockOnMatrixRoom(contextObject.id).catch((error) => alert('The following error occurred: ' + error.data?.error))
           if (knock.room_id) {
             alert('You have asked to join the context. You will be notified once you are accepted.')
+            contextObject.membership = 'knock'
           }
         }
 

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -173,23 +173,25 @@ const Category = ({ projectSpace, onChange, parent }) => {
     // Add this current project to the given context space
 
     // if the join rule of the context is knock, we need to ask to join first.
-    if (contextObject.joinRule === 'knock' && contextObject.membership !== 'join') {
-      if (contextObject.membership === 'knock') {
-        alert('You have already requested to join this context. You will be notified once you are accepted.')
+    if (!contextObject.membership !== 'join') {
+      if (contextObject.joinRule === 'knock' || contextObject.joinRule === 'knock_restricted') {
+        if (contextObject.membership === 'knock') {
+          alert('You have already requested to join this context. You will be notified once you are accepted.')
+          setLoading(false)
+          return
+        }
+        const knockOnRoom = window.confirm('You need to ask to join this context first. Do you want to ask to join the context?')
+        if (knockOnRoom) {
+          const knock = await Matrix.knockOnMatrixRoom(contextObject.id).catch((error) => alert('The following error occurred: ' + error.data?.error))
+          if (knock.room_id) {
+            alert('You have asked to join the context. You will be notified once you are accepted.')
+          }
+        }
+
         setLoading(false)
+
         return
       }
-      const knockOnRoom = window.confirm('You need to ask to join this context first. Do you want to ask to join the context?')
-      if (knockOnRoom) {
-        const knock = await Matrix.knockOnMatrixRoom(contextObject.id).catch((error) => alert('The following error occurred: ' + error.data?.error))
-        if (knock.room_id) {
-          alert('You have asked to join the context. You will be notified once you are accepted.')
-        }
-      }
-
-      setLoading(false)
-
-      return
     }
     const addToContext = await Matrix.addSpaceChild(contextSpace, projectSpace)
       .catch(async () => {

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -166,7 +166,6 @@ const Category = ({ projectSpace, onChange, parent }) => {
       delete projectSpaceMetaEvent.context
       await matrixClient.sendStateEvent(projectSpace, 'dev.medienhaus.meta', projectSpaceMetaEvent).catch(console.log)
     }
-    console.log('contextObject', contextObject)
     if (!contextObject.membership) {
       // if there is no membership (most likely because the contextObject came from the api) we need to check if the user is already a member of the context
 
@@ -177,7 +176,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
       // we check to see if the join rule of the context is 'knock' or 'knock_restricted'
       const joinRuleEvent = await Matrix.getMatrixClient().getStateEvent(contextSpace, 'm.room.join_rules')
       console.log('joinRuleEvent', joinRuleEvent)
-      if (joinRuleEvent?.join_rule !== 'knock' || joinRuleEvent.join_rule !== 'knock_restricted') return
+      if (joinRuleEvent?.join_rule !== 'knock' && joinRuleEvent.join_rule !== 'knock_restricted') return
       contextObject.joinRule = joinRuleEvent.join_rule
       const memberEvent = matrixClient.getRoom(contextSpace)
       console.log('memberEvent', memberEvent)

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -11,8 +11,6 @@ import styled from 'styled-components'
 import ContextDropdown from '../../../components/ContextDropdown'
 
 import { triggerApiUpdate, fetchContextTree, fetchId, removeFromParent } from '../../../helpers/MedienhausApiHelper'
-import { useTranslation } from 'react-i18next'
-import { joinRoomIfKnock } from '../../../helpers/joinRoomIfKnocked'
 
 const RemovableLiElement = styled.li`
   display: grid;
@@ -30,7 +28,6 @@ const Category = ({ projectSpace, onChange, parent }) => {
   const [error, setError] = useState('')
   const [inputItems, setInputItems] = useState()
   const matrixClient = Matrix.getMatrixClient()
-  const { t } = useTranslation('content')
 
   const createStructurObject = async () => {
     setLoading(true)
@@ -66,14 +63,6 @@ const Category = ({ projectSpace, onChange, parent }) => {
         const joinRule = _.find(stateEvents, { type: 'm.room.join_rules' })?.content?.join_rule
         // find the membership of the user in the context by checking the m.room.members event and its state_key which is the user_id
         const memberEvent = _.find(stateEvents, { type: 'm.room.member', state_key: matrixClient.getUserId() })
-        // Check if there are any rooms where a user has previously requested access (knocked) and has now been granted permission to join.
-        const autoJoinRoom = await joinRoomIfKnock(spaceId, memberEvent)
-          .catch(error => {
-            alert(t('The following error occurred: {{error}}', { error: error.data?.error }))
-          })
-
-        // if a room was joined, and the user therefore has access to the room, we alert the user
-        if (autoJoinRoom) alert(t(autoJoinRoom.message))
 
         _.set(result, [...path, spaceId], createSpaceObject(spaceId, spaceName, metaEvent, joinRule, memberEvent?.content?.membership))
 

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -188,7 +188,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
     // Add this current project to the given context space
 
     // if the join rule of the context is knock, we need to ask to join first.
-    if (!contextObject.membership !== 'join') {
+    if (contextObject.membership !== 'join') {
       if (contextObject.joinRule === 'knock' || contextObject.joinRule === 'knock_restricted') {
         if (contextObject.membership === 'knock') {
           alert('You have already requested to join this context. You will be notified once you are accepted.')

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -10,7 +10,7 @@ import findValueDeep from 'deepdash/findValueDeep'
 import styled from 'styled-components'
 import ContextDropdown from '../../../components/ContextDropdown'
 
-import { triggerApiUpdate, fetchContextTree, fetchId, removeFromParent } from '../../../helpers/MedienhausApiHelper'
+import { fetchContextTree, fetchId, removeFromParent, triggerApiUpdate } from '../../../helpers/MedienhausApiHelper'
 
 const RemovableLiElement = styled.li`
   display: grid;
@@ -170,16 +170,11 @@ const Category = ({ projectSpace, onChange, parent }) => {
       // if there is no membership (most likely because the contextObject came from the api) we need to check if the user is already a member of the context
 
       // first we check if the user is already a member of the context
-      const membership = matrixClient.getRoom(contextSpace)?.getMyMembership()
-      console.log('membership', membership)
-      contextObject.membership = membership
+      contextObject.membership = matrixClient.getRoom(contextSpace)?.getMyMembership()
       // we check to see if the join rule of the context is 'knock' or 'knock_restricted'
       const joinRuleEvent = await Matrix.getMatrixClient().getStateEvent(contextSpace, 'm.room.join_rules')
-      console.log('joinRuleEvent', joinRuleEvent)
       if (joinRuleEvent?.join_rule !== 'knock' && joinRuleEvent.join_rule !== 'knock_restricted') return
       contextObject.joinRule = joinRuleEvent.join_rule
-      const memberEvent = matrixClient.getRoom(contextSpace)
-      console.log('memberEvent', memberEvent)
     }
     // If this project was in a different context previously we should try to take it out of the old context
 

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -35,11 +35,13 @@ const Category = ({ projectSpace, onChange, parent }) => {
       const result = {} // the resulting tree structure
       let hasContext = false // we use a boolean to know if a content is in a context which we need for the publishProject component in /create
 
-      function createSpaceObject (id, name, metaEvent) {
+      function createSpaceObject (id, name, metaEvent, joinRule, membership) {
         return {
           id,
           name,
           type: metaEvent.content.type,
+          joinRule: joinRule,
+          membership: membership,
           children: {}
         }
       }
@@ -56,7 +58,12 @@ const Category = ({ projectSpace, onChange, parent }) => {
         const nameEvent = _.find(stateEvents, { type: 'm.room.name' })
         if (!nameEvent) return
         const spaceName = nameEvent.content.name
-        _.set(result, [...path, spaceId], createSpaceObject(spaceId, spaceName, metaEvent))
+
+        // check the join rule of the context
+        const joinRule = _.find(stateEvents, { type: 'm.room.join_rules' })?.content?.join_rule
+        // find the membership of the user in the context by checking the m.room.members event and its state_key which is the user_id
+        const membership = _.find(stateEvents, { type: 'm.room.member', state_key: matrixClient.getUserId() })?.content?.membership
+        _.set(result, [...path, spaceId], createSpaceObject(spaceId, spaceName, metaEvent, joinRule, membership))
 
         console.log(`getting children for ${spaceId} / ${spaceName}`)
         for (const event of stateEvents) {
@@ -93,6 +100,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
   }
 
   const fetchParentsFromApi = async () => {
+    // @TODO make sure api returns join rules
     const fetchParents = await fetchId(projectSpace)
     if (fetchParents.parents) {
       if (_.isEmpty(fetchParents.parents)) {
@@ -163,13 +171,35 @@ const Category = ({ projectSpace, onChange, parent }) => {
     // if (currentContext && currentContext !== contextSpace) await Matrix.removeSpaceChild(currentContext, projectSpace).catch(console.log)
 
     // Add this current project to the given context space
+
+    // if the join rule of the context is knock, we need to ask to join first.
+    if (contextObject.joinRule === 'knock' && contextObject.membership !== 'join') {
+      if (contextObject.membership === 'knock') {
+        alert('You have already requested to join this context. You will be notified once you are accepted.')
+        setLoading(false)
+        return
+      }
+      const knockOnRoom = window.confirm('You need to ask to join this context first. Do you want to ask to join the context?')
+      if (knockOnRoom) {
+        const knock = await Matrix.knockOnMatrixRoom(contextObject.id).catch((error) => alert('The following error occurred: ' + error.data?.error))
+        if (knock.room_id) {
+          alert('You have asked to join the context. You will be notified once you are accepted.')
+        }
+      }
+
+      setLoading(false)
+
+      return
+    }
     const addToContext = await Matrix.addSpaceChild(contextSpace, projectSpace)
       .catch(async () => {
-      // if we cant add the content to a context we try to join the context
+        // if we can't add the content to a context we check the join_rules of the context
+
+        // if we cant add the content to a context we try to join the context
         const joinRoom = await matrixClient.joinRoom(contextSpace).catch(console.log)
         if (joinRoom) {
           console.log('joined room')
-          // then try to add the conent to the context again
+          // then try to add the content to the context again
           const addToContext = await Matrix.addSpaceChild(contextSpace, projectSpace).catch(console.log)
           if (addToContext?.event_id) {
             setContexts(contexts => {

--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -27,7 +27,7 @@ import UdKLocationContext from './Context/UdKLocationContext'
 import styled from 'styled-components'
 import * as Showdown from 'showdown'
 import { triggerApiUpdate } from '../../helpers/MedienhausApiHelper'
-import TextNavigation from '../../components/medienhausUI/textNavigation'
+// import TextNavigation from '../../components/medienhausUI/textNavigation'
 import Tags from './Tags'
 import SimpleButton from '../../components/medienhausUI/simpleButton'
 


### PR DESCRIPTION
This PR introduces a new feature which allows users to request access to specific spaces.

**TODO's:**

- [x] Prompt users to request access to a space when the space's join rule is set to `knock` or `knock_restricted`.
- [x] Check if users have already requested access
- [x] Enable automatic joining of a space once the user's request has been accepted, from /content and /create routes. 
- [x] Alert the user when their request has been processed  by a moderator
- [x] Add API support
- [x] use `matrixClient.on` to listen for membership changes, and alert the user once they have been accepted (or rejected) (A first attempt at this can be found [here](https://github.com/medienhaus/medienhaus-cms/tree/context-knock-event-listener))

**Known Bugs:**

- the matrix client doesnt seem to update the users membership immediately, which causes the successful alert message to show up after a reload until the client was updated. AUtomatically resolves after a few mminutes. Since most users probably won't manually reload after being accepted, I don't consider this a blocker.

Optional:

- [ ] automatically add the content to the context for which access was requested once it was granted
- [ ] use custom modal dialog instead of alert and confirm

