### PR TITLE
Refactor /create to make it more concise 

### DIFF
--- a/src/routes/create/LanguageSelection/index.js
+++ b/src/routes/create/LanguageSelection/index.js
@@ -1,0 +1,149 @@
+import ISO6391 from 'iso-639-1'
+import config from '../../../config.json'
+import SimpleButton from '../../../components/medienhausUI/simpleButton'
+import { languageUtils } from '../languageUtils'
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
+import Matrix from '../../../Matrix'
+
+const Wrapper = styled.section`
+  display: grid;
+  grid-gap: var(--margin);
+  grid-auto-flow: row;
+
+  /* unset margin-top for each direct child element directly following a previous one */
+  & > * + * {
+    margin-top: unset;
+  }
+`
+
+const LanguageCancelConfirm = styled.div`
+  display: flex;
+  gap: var(--margin);
+`
+
+const LanguageSectionAdd = styled.div`
+  display: grid;
+  grid-gap: var(--margin);
+  grid-auto-flow: row;
+`
+const LanguageSectionSelect = styled.div`
+  display: flex;
+  gap: var(--margin);
+  
+  > button {
+  width: calc(var(--margin) * 2.5);
+}
+`
+/**
+ * LanguageSelectionComponent is a React component for language selection.
+ *
+ * @param {boolean} addingAdditionalLanguage - Whether additional language is being added.
+ * @param {Function} setContentLang - Function to set the content language.
+ * @param {Function} setDescription - Function to set the description.
+ * @param {Array} languages - Array of languages.
+ * @param {Function} setAddingAdditionalLanguage - Function to set whether additional language is being added.
+ * @param {Function} inviteCollaborators - Function to invite collaborators.
+ * @param {string} projectSpace - The project space.
+ * @param {Function} setLanguages - Function to set the languages.
+ * @returns {JSX.Element} The rendered component.
+ */
+
+const LanguageSelection = ({
+  addingAdditionalLanguage,
+  setContentLang,
+  setDescription,
+  languages,
+  setAddingAdditionalLanguage,
+  inviteCollaborators,
+  projectSpace,
+  setLanguages
+}) => {
+  const [newLang, setNewLang] = useState('')
+  const { t } = useTranslation('create')
+  const matrixClient = Matrix.getMatrixClient()
+
+  return (
+    <Wrapper className="request">
+      <LanguageSectionSelect>
+        <select
+          disabled={addingAdditionalLanguage}
+          onChange={(e) => {
+            setContentLang(e.target.value)
+            setDescription()
+          }}
+        >
+          {languages.map((lang) => (
+            <option value={lang} key={lang}>
+              {ISO6391.getName(lang)}
+            </option>
+          ))}
+        </select>
+        {config.medienhaus?.customLanguages && (
+          <SimpleButton
+            value="languageUtils"
+            key="lang"
+            disabled={addingAdditionalLanguage}
+            onClick={(e) => {
+              if (!addingAdditionalLanguage) {
+                setAddingAdditionalLanguage(true)
+              }
+            }}
+          >
+            +
+          </SimpleButton>
+        )}
+      </LanguageSectionSelect>
+      <LanguageSectionAdd>
+        {config.medienhaus?.customLanguages && (
+          <>
+            {addingAdditionalLanguage && (
+              <select
+                onChange={(e) => setNewLang(e.target.value)}
+                value={newLang || ''}
+              >
+                <option disabled value="">
+                  {t('select language')}
+                </option>
+                {ISO6391.getAllNames().map((lang, i) => (
+                  <option key={i} value={ISO6391.getCode(lang)}>
+                    {lang}
+                  </option>
+                ))}
+              </select>
+            )}
+            {addingAdditionalLanguage && (
+              <LanguageCancelConfirm>
+                <SimpleButton
+                  cancel
+                  onClick={() => {
+                    setAddingAdditionalLanguage(false)
+                    setNewLang('')
+                  }}
+                >
+                  {t('CANCEL')}
+                </SimpleButton>
+                <SimpleButton
+                  value="languageUtils"
+                  key="lang"
+                  onClick={(e) => {
+                    if (
+                      addingAdditionalLanguage &&
+                                            newLang?.length > 0
+                    ) {
+                      languageUtils(matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage)
+                    }
+                  }}
+                >
+                  {t('Add')}
+                </SimpleButton>
+              </LanguageCancelConfirm>
+            )}
+          </>
+        )}
+      </LanguageSectionAdd>
+    </Wrapper>
+  )
+}
+export default LanguageSelection

--- a/src/routes/create/LanguageSelection/index.js
+++ b/src/routes/create/LanguageSelection/index.js
@@ -1,7 +1,7 @@
 import ISO6391 from 'iso-639-1'
 import config from '../../../config.json'
 import SimpleButton from '../../../components/medienhausUI/simpleButton'
-import { languageUtils } from '../languageUtils'
+import { languageUtils } from '../utils/languageUtils'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'

--- a/src/routes/create/addLanguage.js
+++ b/src/routes/create/addLanguage.js
@@ -1,0 +1,77 @@
+import Matrix from '../../Matrix'
+
+export const addLanguage = async (matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage) => {
+  const createLanguageSpace = async (lang) => {
+    const opts = (template, name, history) => {
+      return {
+        preset: 'private_chat',
+        name: name,
+        room_version: '9',
+        creation_content: { type: 'm.space' },
+        initial_state: [
+          {
+            type: 'm.room.history_visibility',
+            content: { history_visibility: history }
+          }, //  world_readable
+          {
+            type: 'dev.medienhaus.meta',
+            content: {
+              version: '0.4',
+              type: 'item',
+              template: template,
+              application: process.env.REACT_APP_APP_NAME,
+              published: 'draft'
+            }
+          },
+          {
+            type: 'm.room.guest_access',
+            state_key: '',
+            content: { guest_access: 'can_join' }
+          }
+        ],
+        power_level_content_override: {
+          ban: 50,
+          events: {
+            'm.room.avatar': 50,
+            'm.room.canonical_alias': 50,
+            'm.room.encryption': 100,
+            'm.room.history_visibility': 100,
+            'm.room.name': 50,
+            'm.room.power_levels': 100,
+            'm.room.server_acl': 100,
+            'm.room.tombstone': 100,
+            'm.space.child': 50,
+            'm.room.topic': 50,
+            'm.room.pinned_events': 50,
+            'm.reaction': 50,
+            'im.vector.modular.widgets': 50
+          },
+          events_default: 50,
+          historical: 100,
+          invite: 50,
+          kick: 50,
+          redact: 50,
+          state_default: 50,
+          users_default: 0
+        },
+        visibility: 'private'
+      }
+    }
+    const languageRoom = await matrixClient.createRoom(
+      opts('lang', lang, 'shared')
+    )
+    await inviteCollaborators(languageRoom.room_id)
+    await Matrix.addSpaceChild(projectSpace, languageRoom.room_id)
+  }
+
+  if (languages.includes(newLang)) {
+    console.log('error')
+    setNewLang('')
+    return
+  }
+
+  setLanguages([...languages, newLang])
+  setAddingAdditionalLanguage(false)
+  console.log(projectSpace)
+  await createLanguageSpace(newLang)
+}

--- a/src/routes/create/gutenbergUtils.js
+++ b/src/routes/create/gutenbergUtils.js
@@ -1,0 +1,238 @@
+import _ from 'lodash'
+import createBlock from './matrix_create_room'
+import * as Showdown from 'showdown'
+
+const ShowdownConverter = new Showdown.Converter()
+export const saveGutenbergEditorToMatrix = async (isSavingGutenbergContents, setIsSavingGutenbergContents, temporaryGutenbergContents, blocksRef, deleteRoom, spaceObjectRef, contentLangRef, fetchContentBlocks, matrixClient, gutenbergIdToMatrixRoomIdRef, addToMap, isCollab, inviteCollaborators, gutenbergContent, setSaveTimestampToCurrentTime, setTemporaryGutenbergContents) => {
+  if (isSavingGutenbergContents) return
+
+  setIsSavingGutenbergContents(true)
+
+  const orderOfRooms = []
+  let gutenbergBlocks = [...temporaryGutenbergContents]
+
+  // filter out all empty gutenberg blocks -- we want to ignore those
+  gutenbergBlocks = gutenbergBlocks.filter((block) => {
+    return !(
+      block.name === 'core/paragraph' &&
+            _.get(block, 'attributes.content', '') === ''
+    )
+  })
+
+  for (const block of blocksRef.current) {
+    let deletedARoom = false
+    if (!_.find(gutenbergBlocks, { clientId: block.room_id })) {
+      await deleteRoom(
+        block.room_id,
+        spaceObjectRef.current?.rooms.filter(
+          (room) => room.name === contentLangRef.current
+        )[0].room_id
+      )
+      deletedARoom = true
+    }
+    if (deletedARoom) fetchContentBlocks()
+  }
+
+  for (const [index, block] of gutenbergBlocks.entries()) {
+    let roomId = block.clientId
+    let contentType
+    switch (block.name) {
+      case 'core/list':
+        contentType = block.attributes.ordered ? 'ol' : 'ul'
+        break
+      case 'core/code':
+        contentType = 'code'
+        break
+      case 'medienhaus/heading':
+      case 'medienhaus/image':
+      case 'medienhaus/audio':
+      case 'medienhaus/file':
+      case 'medienhaus/video':
+      case 'medienhaus/playlist':
+      case 'medienhaus/livestream':
+        contentType = block.name.replace('medienhaus/', '')
+        break
+      case 'medienhaus/bigbluebutton':
+        contentType = 'bbb'
+        break
+      default:
+        contentType = 'text'
+    }
+
+    if (!matrixClient.getRoom(roomId)) {
+      // this is a newly created block
+      if (!gutenbergIdToMatrixRoomIdRef.current[block.clientId]) {
+        const createdBlock = await createBlock(
+          null,
+          contentType,
+          index,
+          spaceObjectRef.current?.rooms.filter(
+            (room) => room.name === contentLangRef.current
+          )[0].room_id
+        )
+        addToMap(block.clientId, createdBlock)
+        // if the item is a collaboration we need to invite all collaborators to the newly created block
+        if (isCollab) await inviteCollaborators(createdBlock)
+      }
+
+      roomId = gutenbergIdToMatrixRoomIdRef.current[block.clientId]
+    }
+
+    // ensure room name is correct
+    if (
+      _.get(_.find(blocksRef.current, { room_id: roomId }), 'name') !==
+            `${index}_${contentType}`
+    ) {
+      await matrixClient.setRoomName(roomId, `${index}_${contentType}`)
+    }
+    orderOfRooms.push(roomId)
+
+    // lastly, if the content of this block has not changed, skip this block, otherwise ...
+    if (
+      _.isEqual(
+        block.attributes,
+        _.get(_.find(gutenbergContent, { clientId: roomId }), 'attributes')
+      ) &&
+            _.isEqual(
+              block.name,
+              _.get(_.find(gutenbergContent, { clientId: roomId }), 'name')
+            )
+    ) {
+      continue
+    }
+
+    // ... write new contents to room
+    switch (block.name) {
+      case 'core/list':
+        await matrixClient.sendMessage(roomId, {
+          // body: (block.attributes.ordered ? '<ol>' : '<ul>') + block.attributes.values + (block.attributes.ordered ? '</ol>' : '</ul>'), // body should have unformated list (markdowm)
+          body: block.attributes.values
+            .replaceAll('<li>', '- ')
+            .replaceAll('</li>', '\n'), // @TODO add case for ol
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          formatted_body:
+                        (block.attributes.ordered ? '<ol>' : '<ul>') +
+                        block.attributes.values +
+                        (block.attributes.ordered ? '</ol>' : '</ul>')
+        })
+        break
+      case 'core/code':
+        await matrixClient.sendMessage(roomId, {
+          body: block.attributes.content,
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          formatted_body: `<pre><code>${block.attributes.content}</code></pre>`
+        })
+        break
+      case 'medienhaus/heading':
+        await matrixClient.sendMessage(roomId, {
+          body: '### ' + block.attributes.content,
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          formatted_body: `<h3>${block.attributes.content}</h3>`
+        })
+        break
+      case 'medienhaus/image':
+        // If this image was uploaded to Matrix already, we don't do anything
+        if (block.attributes.url) break
+        // If the user has not provided an image and the file input was left "empty", we don't do anything either
+        if (!block.attributes.file) break
+        // eslint-disable-next-line no-case-declarations,prefer-const
+        let uploadedImage = await matrixClient.uploadContent(
+          block.attributes.file,
+          { name: block.attributes.file.name }
+        )
+        await matrixClient.sendImageMessage(
+          roomId,
+          null,
+          uploadedImage?.content_uri,
+          {
+            mimetype: block.attributes.file.type,
+            size: block.attributes.file.size,
+            name: block.attributes.file.name,
+            author: block.attributes.author,
+            license: block.attributes.license,
+            alt: block.attributes.alttext
+          },
+          block.attributes.alttext,
+          // Beware: We need to provide an empty callback because otherwise matrix-js-sdk fails
+          // See https://github.com/medienhaus/medienhaus-cms/issues/173
+          () => {
+          }
+        )
+        break
+      case 'medienhaus/audio':
+        // If this audio was uploaded to Matrix already, we don't do anything
+        if (block.attributes.url) break
+        // eslint-disable-next-line no-case-declarations,prefer-const
+        let uploadedAudio = await matrixClient.uploadContent(
+          block.attributes.file,
+          { name: block.attributes.file.name }
+        )
+        await matrixClient.sendMessage(roomId, {
+          body: block.attributes.file.name,
+          info: {
+            size: block.attributes.file.size,
+            mimetype: block.attributes.file.type,
+            name: block.attributes.file.name,
+            author: block.attributes.author,
+            license: block.attributes.license,
+            alt: block.attributes.alttext
+          },
+          msgtype: 'm.audio',
+          url: uploadedAudio?.content_uri
+        })
+        break
+      case 'medienhaus/file':
+        // If this file was uploaded to Matrix already, we don't do anything
+        if (block.attributes.url) break
+        // eslint-disable-next-line no-case-declarations,prefer-const
+        let uploadedFile = await matrixClient.uploadContent(
+          block.attributes.file,
+          { name: block.attributes.file.name }
+        )
+        await matrixClient.sendMessage(roomId, {
+          body: block.attributes.file.name,
+          info: {
+            size: block.attributes.file.size,
+            mimetype: block.attributes.file.type,
+            name: block.attributes.file.name,
+            author: block.attributes.author,
+            license: block.attributes.license,
+            alt: block.attributes.alttext
+          },
+          msgtype: 'm.file',
+          url: uploadedFile?.content_uri
+        })
+        break
+      default:
+        await matrixClient.sendMessage(roomId, {
+          body: ShowdownConverter.makeMarkdown(block.attributes.content)
+            .replaceAll('<br>', '')
+            .replaceAll('<br />', ''),
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          formatted_body: block.attributes.content
+        })
+    }
+  }
+
+  // ensure correct order
+  await matrixClient.sendStateEvent(
+    spaceObjectRef.current?.rooms.filter(
+      (room) => room.name === contentLangRef.current
+    )[0].room_id,
+    'dev.medienhaus.order',
+    { order: orderOfRooms }
+  )
+
+  // update our "last saved  timestamp"
+  setSaveTimestampToCurrentTime()
+
+  await fetchContentBlocks()
+
+  setTemporaryGutenbergContents(undefined)
+
+  setIsSavingGutenbergContents(false)
+}

--- a/src/routes/create/gutenbergUtils.js
+++ b/src/routes/create/gutenbergUtils.js
@@ -1,12 +1,28 @@
 import _ from 'lodash'
 import createBlock from './matrix_create_room'
 import * as Showdown from 'showdown'
+import Matrix from '../../Matrix'
 
+const matrixClient = Matrix.getMatrixClient()
 const ShowdownConverter = new Showdown.Converter()
 const nl2br = function (str) {
   return str.split('\n').join('<br>')
 }
-export const saveGutenbergEditorToMatrix = async (isSavingGutenbergContents, setIsSavingGutenbergContents, temporaryGutenbergContents, blocksRef, deleteRoom, spaceObjectRef, contentLangRef, fetchContentBlocks, matrixClient, gutenbergIdToMatrixRoomIdRef, addToMap, isCollab, inviteCollaborators, gutenbergContent, setSaveTimestampToCurrentTime, setTemporaryGutenbergContents) => {
+export const saveGutenbergEditorToMatrix = async (isSavingGutenbergContents,
+  setIsSavingGutenbergContents,
+  temporaryGutenbergContents,
+  blocksRef,
+  deleteRoom,
+  spaceObjectRef,
+  contentLangRef,
+  fetchContentBlocks,
+  gutenbergIdToMatrixRoomIdRef,
+  isCollab,
+  inviteCollaborators,
+  gutenbergContent,
+  setSaveTimestampToCurrentTime,
+  setTemporaryGutenbergContents,
+  setGutenbergIdToMatrixRoomId) => {
   if (isSavingGutenbergContents) return
 
   setIsSavingGutenbergContents(true)
@@ -73,7 +89,7 @@ export const saveGutenbergEditorToMatrix = async (isSavingGutenbergContents, set
             (room) => room.name === contentLangRef.current
           )[0].room_id
         )
-        addToMap(block.clientId, createdBlock)
+        addToMap(block.clientId, createdBlock, setGutenbergIdToMatrixRoomId)
         // if the item is a collaboration we need to invite all collaborators to the newly created block
         if (isCollab) await inviteCollaborators(createdBlock)
       }
@@ -357,4 +373,18 @@ export const fetchContentsForGutenberg = async (blocks, matrixClient, setGutenbe
     }
   }
   setGutenbergContent(contents)
+}
+
+export const warnUserAboutUnsavedChanges = (e, temporaryGutenbergContents) => {
+  // @TODO this only works on reloads, changing the route via the navigation doesn't trigger this
+  if (temporaryGutenbergContents) {
+    e.returnValue = 'Please save your changes'
+    return e.returnValue
+  }
+}
+export const addToMap = (blockId, roomId, setGutenbergIdToMatrixRoomId) => {
+  setGutenbergIdToMatrixRoomId((prevState) => ({
+    ...prevState,
+    [blockId]: roomId
+  }))
 }

--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -26,8 +26,8 @@ import UdKLocationContext from './Context/UdKLocationContext'
 import styled from 'styled-components'
 import { triggerApiUpdate } from '../../helpers/MedienhausApiHelper'
 import Tags from './Tags'
-import { fetchLanguages, onChangeDescription } from './languageUtils'
-import { fetchContentsForGutenberg, saveGutenbergEditorToMatrix, warnUserAboutUnsavedChanges } from './gutenbergUtils'
+import { fetchLanguages, onChangeDescription } from './utils/languageUtils'
+import { fetchContentsForGutenberg, saveGutenbergEditorToMatrix, warnUserAboutUnsavedChanges } from './utils/gutenbergUtils'
 import LanguageSelection from './LanguageSelection'
 
 const GutenbergWrapper = styled.div`

--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -26,41 +26,9 @@ import UdKLocationContext from './Context/UdKLocationContext'
 import styled from 'styled-components'
 import { triggerApiUpdate } from '../../helpers/MedienhausApiHelper'
 import Tags from './Tags'
-import SimpleButton from '../../components/medienhausUI/simpleButton'
-import { fetchLanguages, languageUtils, onChangeDescription } from './languageUtils'
+import { fetchLanguages, onChangeDescription } from './languageUtils'
 import { fetchContentsForGutenberg, saveGutenbergEditorToMatrix, warnUserAboutUnsavedChanges } from './gutenbergUtils'
-
-const LanguageSection = styled.section`
-  display: grid;
-  grid-gap: var(--margin);
-  grid-auto-flow: row;
-
-  /* unset margin-top for each direct child element directly following a previous one */
-  & > * + * {
-    margin-top: unset;
-  }
-`
-
-const LanguageCancelConfirm = styled.div`
-  display: flex;
-  gap: var(--margin);
-`
-
-const LanguageSectionAdd = styled.div`
-  display: grid;
-  grid-gap: var(--margin);
-  grid-auto-flow: row;
-`
-const LanguageSectionSelect = styled.div`
-  display: flex;
-  gap: var(--margin);
-  
-  > button {
-  width: calc(var(--margin) * 2.5);
-}
-
-
-`
+import LanguageSelection from './LanguageSelection'
 
 const GutenbergWrapper = styled.div`
   position: relative;
@@ -178,7 +146,6 @@ const Create = () => {
     useState(undefined)
 
   const [languages, setLanguages] = useState([])
-  const [newLang, setNewLang] = useState('')
   const [addingAdditionalLanguage, setAddingAdditionalLanguage] =
     useState(false)
 
@@ -669,107 +636,22 @@ const Create = () => {
 
           <section className="content">
             <h3>{t('Content')}</h3>
-            {/*
-            <select
-              value={contentLang} onChange={(e) => {
-                if (temporaryGutenbergContents) {
-                  alert('Please save your changes first')
-                  return
-                }
-                setContentLang(e.target.value)
-                setDescription()
-              }}
-            >
-              {config.medienhaus?.languages.map((lang) => (
-                <option value={lang} key={lang}>{lang.toUpperCase() + ' -- ' + ISO6391.getName(lang)}</option>
-              ))}
-            </select>
-            */}
-            <LanguageSection className="request">
-              <LanguageSectionSelect>
-                <select
-                  disabled={addingAdditionalLanguage}
-                  onChange={(e) => {
-                    setContentLang(e.target.value)
-                    setDescription()
-                  }}
-                >
-                  {languages.map((lang) => (
-                    <option value={lang} key={lang}>
-                      {ISO6391.getName(lang)}
-                    </option>
-                  ))}
-                </select>
-                {config.medienhaus?.customLanguages && (
-                  <SimpleButton
-                    value="languageUtils"
-                    key="lang"
-                    disabled={addingAdditionalLanguage}
-                    onClick={(e) => {
-                      if (!addingAdditionalLanguage) {
-                        setAddingAdditionalLanguage(true)
-                      }
-                    }}
-                  >
-                    +
-                  </SimpleButton>
-                )}
-              </LanguageSectionSelect>
-              <LanguageSectionAdd>
-                {config.medienhaus?.customLanguages && (
-                  <>
-                    {addingAdditionalLanguage && (
-                      <select
-                        onChange={(e) => setNewLang(e.target.value)}
-                        value={newLang || ''}
-                      >
-                        <option disabled value="">
-                          {t('select language')}
-                        </option>
-                        {ISO6391.getAllNames().map((lang, i) => (
-                          <option key={i} value={ISO6391.getCode(lang)}>
-                            {lang}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                    {addingAdditionalLanguage && (
-                      <LanguageCancelConfirm>
-                        <SimpleButton
-                          cancel
-                          onClick={() => {
-                            setAddingAdditionalLanguage(false)
-                            setNewLang('')
-                          }}
-                        >
-                          {t('CANCEL')}
-                        </SimpleButton>
-                        <SimpleButton
-                          value="languageUtils"
-                          key="lang"
-                          onClick={(e) => {
-                            if (
-                              addingAdditionalLanguage &&
-                              newLang?.length > 0
-                            ) {
-                              languageUtils(matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage)
-                            }
-                          }}
-                        >
-                          {t('Add')}
-                        </SimpleButton>
-                      </LanguageCancelConfirm>
-                    )}
-                  </>
-                )}
-              </LanguageSectionAdd>
-            </LanguageSection>
+            <LanguageSelection
+              setLanguages={setLanguages}
+              languages={languages}
+              projectSpace={projectSpace}
+              setAddingAdditionalLanguage={setAddingAdditionalLanguage}
+              addingAdditionalLanguage={addingAdditionalLanguage}
+              setContentLang={setContentLang}
+              setDescription={setDescription}
+              inviteCollaborators={inviteCollaborators}
+            />
             {spaceObject && (description || description === '')
               ? (
                 <ProjectDescription
                   disabled={addingAdditionalLanguage}
                   description={description[contentLang]}
-                  callback={() => onChangeDescription(description, contentLang, matrixClient, spaceObject, fetchSpace, projectSpace)}
+                  callback={(updatedDescription) => onChangeDescription(updatedDescription, contentLang, matrixClient, spaceObject, fetchSpace, projectSpace)}
                   language={ISO6391.getName(contentLang)}
                 />
                 )

--- a/src/routes/create/languageUtils.js
+++ b/src/routes/create/languageUtils.js
@@ -1,4 +1,6 @@
 import Matrix from '../../Matrix'
+import config from '../../config.json'
+import { triggerApiUpdate } from '../../helpers/MedienhausApiHelper'
 
 export const languageUtils = async (matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage) => {
   const createLanguageSpace = async (lang) => {
@@ -84,4 +86,23 @@ export const fetchLanguages = async (id) => {
     ?.filter((room) => room.room_id !== id && room.name.length === 2)
     .map((room) => room.name)
   return languageSpaces
+}
+
+export const onChangeDescription = async (description, contentLang, matrixClient, spaceObject, fetchSpace, projectSpace) => {
+  // if the selected content language is english we save the description in the project space topic
+  contentLang === config.medienhaus?.languages[0] &&
+  (await matrixClient
+    .setRoomTopic(spaceObject.rooms[0].room_id, description)
+    .catch(console.log))
+  // here we set the description for the selected language space
+  const contentRoom = spaceObject.rooms.filter(
+    (room) => room.name === contentLang
+  )
+  const changeTopic = await matrixClient
+    .setRoomTopic(contentRoom[0].room_id, description)
+    .catch(console.log)
+  fetchSpace(true)
+  if (config.medienhaus.api) await triggerApiUpdate(projectSpace)
+  // @TODO setSpaceObject(spaceObject => ({...spaceObject, rooms: [...spaceObject.rooms, ]}))
+  return changeTopic
 }

--- a/src/routes/create/languageUtils.js
+++ b/src/routes/create/languageUtils.js
@@ -1,6 +1,6 @@
 import Matrix from '../../Matrix'
 
-export const addLanguage = async (matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage) => {
+export const languageUtils = async (matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage) => {
   const createLanguageSpace = async (lang) => {
     const opts = (template, name, history) => {
       return {
@@ -74,4 +74,14 @@ export const addLanguage = async (matrixClient, inviteCollaborators, projectSpac
   setAddingAdditionalLanguage(false)
   console.log(projectSpace)
   await createLanguageSpace(newLang)
+}
+
+export const fetchLanguages = async (id) => {
+  const spaces = await Matrix.roomHierarchy(id, 1000, 1)
+  // we filter out all of the spaces which are not the parent space itstelf as well as assuming that if it is an two letter space it is a language space based on the ISO639-1 standard
+  // @TODO this is a very hacky way to determine if a space is a language space, it should be discussed if we should check that with additional calls to check the dev.medienhaus.meta event
+  const languageSpaces = spaces
+    ?.filter((room) => room.room_id !== id && room.name.length === 2)
+    .map((room) => room.name)
+  return languageSpaces
 }

--- a/src/routes/create/utils/gutenbergUtils.js
+++ b/src/routes/create/utils/gutenbergUtils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
-import createBlock from './matrix_create_room'
+import createBlock from '../matrix_create_room'
 import * as Showdown from 'showdown'
-import Matrix from '../../Matrix'
+import Matrix from '../../../Matrix'
 
 const matrixClient = Matrix.getMatrixClient()
 const ShowdownConverter = new Showdown.Converter()

--- a/src/routes/create/utils/languageUtils.js
+++ b/src/routes/create/utils/languageUtils.js
@@ -1,6 +1,6 @@
-import Matrix from '../../Matrix'
-import config from '../../config.json'
-import { triggerApiUpdate } from '../../helpers/MedienhausApiHelper'
+import Matrix from '../../../Matrix'
+import config from '../../../config.json'
+import { triggerApiUpdate } from '../../../helpers/MedienhausApiHelper'
 
 export const languageUtils = async (matrixClient, inviteCollaborators, projectSpace, languages, newLang, setNewLang, setLanguages, setAddingAdditionalLanguage) => {
   const createLanguageSpace = async (lang) => {


### PR DESCRIPTION
This PR refactoes the Create component in src/routes/create/index.js. The main goal of these changes is to improve code readability. 

- moved gutenberg and language functions into two separate util files.
- created a LanguageSelection component