### PR TITLE
Refactor `createStructureObject` function and make it reusable

### DIFF
--- a/src/helpers/createMatrixStructureObject.js
+++ b/src/helpers/createMatrixStructureObject.js
@@ -1,6 +1,17 @@
 import * as _ from 'lodash'
 import Matrix from '../Matrix'
 
+/**
+ * This function creates a structure object for a Matrix space.
+ * It recursively scans through the children of a given space and builds a tree structure.
+ *
+ * @async
+ * @param {string} parentId - The ID of the parent space.
+ * @param {string} projectSpace - The ID of the project space.
+ * @param {function} setContexts - A function to set the contexts.
+ * @returns {Promise<Array>} - A promise that resolves to an array containing the resulting tree structure and a boolean indicating if a content is in a context.
+ */
+
 export const createMatrixStructureObject = async (parentId, projectSpace, setContexts) => {
   const matrixClient = Matrix.getMatrixClient()
   async function getSpaceStructure (motherSpaceRoomId, includeRooms) {

--- a/src/helpers/createMatrixStructureObject.js
+++ b/src/helpers/createMatrixStructureObject.js
@@ -1,0 +1,73 @@
+import * as _ from 'lodash'
+import Matrix from '../Matrix'
+
+export const createMatrixStructureObject = async (parentId, projectSpace, setContexts) => {
+  const matrixClient = Matrix.getMatrixClient()
+  async function getSpaceStructure (motherSpaceRoomId, includeRooms) {
+    const result = {} // the resulting tree structure
+    let hasContext = false // we use a boolean to know if a content is in a context which we need for the publishProject component in /create
+
+    function createSpaceObject (id, name, metaEvent, joinRule, membership, topic) {
+      return {
+        id,
+        name,
+        type: metaEvent.content.type,
+        joinRule: joinRule,
+        membership: membership,
+        topic: topic,
+        children: {}
+      }
+    }
+
+    async function scanForAndAddSpaceChildren (spaceId, path) {
+      if (spaceId === 'undefined') return
+      const stateEvents = await matrixClient.roomState(spaceId).catch(console.log)
+
+      const metaEvent = _.find(stateEvents, { type: 'dev.medienhaus.meta' })
+      if (!metaEvent) return
+      // make sure we only show contexts
+      if (_.get(metaEvent, 'content.type') !== 'context') return
+      // make sure we have a name for the context
+      const nameEvent = _.find(stateEvents, { type: 'm.room.name' })
+      if (!nameEvent) return
+      const spaceName = nameEvent.content.name
+      // get the topic for the context
+      let topic = _.find(stateEvents, { type: 'm.room.topic' })
+      if (topic) topic = topic.content.topic
+
+      // check the join rule of the context
+      const joinRule = _.find(stateEvents, { type: 'm.room.join_rules' })?.content?.join_rule
+      // find the membership of the user in the context by checking the m.room.members event and its state_key which is the user_id
+      const memberEvent = _.find(stateEvents, { type: 'm.room.member', state_key: matrixClient.getUserId() })
+
+      _.set(result, [...path, spaceId], createSpaceObject(spaceId, spaceName, metaEvent, joinRule, memberEvent?.content?.membership, topic))
+
+      if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') console.log(`getting children for ${spaceId} / ${spaceName}`)
+      for (const event of stateEvents) {
+        if (event.type !== 'm.space.child' && !includeRooms) continue
+        if (event.type === 'm.space.child' && _.size(event.content) === 0) continue // check to see if body of content is empty, therefore space has been removed
+        if (setContexts && event.state_key === projectSpace) {
+          setContexts(contexts => {
+            if (contexts) return [...contexts, { name: spaceName, room_id: event.room_id }]
+            else return [{ name: spaceName, room_id: event.room_id }]
+          }) // add context to the contexts array if the projectspace is a child of it
+          hasContext = true
+        }
+        if (event.room_id !== spaceId) continue
+
+        await scanForAndAddSpaceChildren(event.state_key, [...path, spaceId, 'children'])
+      }
+    }
+
+    await scanForAndAddSpaceChildren(motherSpaceRoomId, [])
+
+    // if (_.isEmpty(result)) setContexts([]) // if the content is in not in any context, yet, we set contexts to an empty array in order to display the publishProject component
+    return [result, hasContext]
+  }
+  if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') console.log('---- started structure ----')
+  const tree = await getSpaceStructure(parentId, false)
+  if (setContexts && !tree[1]) setContexts([]) // if the content is in not in any context, yet, we set contexts to an empty array in order to display the publishProject component
+  // setInputItems(tree[0][parent])
+
+  return tree
+}

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -29,7 +29,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
   const [inputItems, setInputItems] = useState()
   const matrixClient = Matrix.getMatrixClient()
 
-  const createStructurObject = async () => {
+  const createStructureObject = async () => {
     setLoading(true)
     async function getSpaceStructure (motherSpaceRoomId, includeRooms) {
       const result = {} // the resulting tree structure
@@ -127,7 +127,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
       fetchTreeFromApi()
       fetchParentsFromApi()
       setLoading(false)
-    } else createStructurObject()
+    } else createStructureObject()
 
     return () => {
       cancelled = true

--- a/src/routes/create/Category/index.js
+++ b/src/routes/create/Category/index.js
@@ -11,6 +11,7 @@ import styled from 'styled-components'
 import ContextDropdown from '../../../components/ContextDropdown'
 
 import { fetchContextTree, fetchId, removeFromParent, triggerApiUpdate } from '../../../helpers/MedienhausApiHelper'
+import { createMatrixStructureObject } from '../../../helpers/createMatrixStructureObject'
 
 const RemovableLiElement = styled.li`
   display: grid;
@@ -29,70 +30,11 @@ const Category = ({ projectSpace, onChange, parent }) => {
   const [inputItems, setInputItems] = useState()
   const matrixClient = Matrix.getMatrixClient()
 
-  const createStructureObject = async () => {
+  const createObject = async () => {
     setLoading(true)
-    async function getSpaceStructure (motherSpaceRoomId, includeRooms) {
-      const result = {} // the resulting tree structure
-      let hasContext = false // we use a boolean to know if a content is in a context which we need for the publishProject component in /create
-
-      function createSpaceObject (id, name, metaEvent, joinRule, membership) {
-        return {
-          id,
-          name,
-          type: metaEvent.content.type,
-          joinRule: joinRule,
-          membership: membership,
-          children: {}
-        }
-      }
-
-      async function scanForAndAddSpaceChildren (spaceId, path) {
-        if (spaceId === 'undefined') return
-        const stateEvents = await matrixClient.roomState(spaceId).catch(console.log)
-
-        const metaEvent = _.find(stateEvents, { type: 'dev.medienhaus.meta' })
-        if (!metaEvent) return
-        // make sure we only show contexts
-        if (_.get(metaEvent, 'content.type') !== 'context') return
-        // make sure we have a name for the context
-        const nameEvent = _.find(stateEvents, { type: 'm.room.name' })
-        if (!nameEvent) return
-        const spaceName = nameEvent.content.name
-
-        // check the join rule of the context
-        const joinRule = _.find(stateEvents, { type: 'm.room.join_rules' })?.content?.join_rule
-        // find the membership of the user in the context by checking the m.room.members event and its state_key which is the user_id
-        const memberEvent = _.find(stateEvents, { type: 'm.room.member', state_key: matrixClient.getUserId() })
-
-        _.set(result, [...path, spaceId], createSpaceObject(spaceId, spaceName, metaEvent, joinRule, memberEvent?.content?.membership))
-
-        console.log(`getting children for ${spaceId} / ${spaceName}`)
-        for (const event of stateEvents) {
-          if (event.type !== 'm.space.child' && !includeRooms) continue
-          if (event.type === 'm.space.child' && _.size(event.content) === 0) continue // check to see if body of content is empty, therefore space has been removed
-          if (event.state_key === projectSpace) {
-            setContexts(contexts => {
-              if (contexts) return [...contexts, { name: spaceName, room_id: event.room_id }]
-              else return [{ name: spaceName, room_id: event.room_id }]
-            }) // add context to the contexts array if the projectspace is a child of it
-            hasContext = true
-          }
-          if (event.room_id !== spaceId) continue
-
-          await scanForAndAddSpaceChildren(event.state_key, [...path, spaceId, 'children'])
-        }
-      }
-
-      await scanForAndAddSpaceChildren(motherSpaceRoomId, [])
-
-      if (_.isEmpty(result)) setContexts([]) // if the content is in not in any context, yet, we set contexts to an empty array in order to display the publishProject component
-      setLoading(false)
-      return [result, hasContext]
-    }
-    console.log('---- started structure ----')
-    const tree = await getSpaceStructure(parent, false)
-    if (!tree[1]) setContexts([]) // if the content is in not in any context, yet, we set contexts to an empty array in order to display the publishProject component
-    setInputItems(tree[0][parent])
+    const matrixObject = await createMatrixStructureObject(parent, projectSpace, setContexts)
+    setInputItems(matrixObject[0][parent])
+    setLoading(false)
   }
 
   const fetchTreeFromApi = async () => {
@@ -127,7 +69,9 @@ const Category = ({ projectSpace, onChange, parent }) => {
       fetchTreeFromApi()
       fetchParentsFromApi()
       setLoading(false)
-    } else createStructureObject()
+    } else {
+      createObject()
+    }
 
     return () => {
       cancelled = true
@@ -282,7 +226,7 @@ const Category = ({ projectSpace, onChange, parent }) => {
         ? <Loading />
         : <>
           {contexts?.length > 0 && <ul style={{ position: 'relative' }}>
-            {contexts?.map((context, index) => {
+            {contexts?.map((context) => {
               return (
                 <RemovableLiElement key={context.room_id}>
                   <span>{context.name} </span>

--- a/src/routes/moderate/index.js
+++ b/src/routes/moderate/index.js
@@ -44,7 +44,7 @@ const Moderate = () => {
 
   const { t } = useTranslation('moderate')
 
-  const createStructurObject = useCallback(async () => {
+  const createStructureObject = useCallback(async () => {
     async function getSpaceStructure (matrixClient, motherSpaceRoomId, includeRooms) {
       const result = {}
 
@@ -108,7 +108,7 @@ const Moderate = () => {
       let tree = {}
 
       // with no api we have to create the structure ourselves
-      if (!config.medienhaus.api) tree = await createStructurObject()
+      if (!config.medienhaus.api) tree = await createStructureObject()
       for (const space of joinedSpaces) {
         if (space.meta.type !== 'context') continue
         if (space.powerLevel < 50) continue
@@ -159,7 +159,7 @@ const Moderate = () => {
     return () => {
       controller && controller.abort()
     }
-  }, [createStructurObject, joinedSpaces])
+  }, [createStructureObject, joinedSpaces])
 
   useEffect(() => {
     let cancelled = false

--- a/src/routes/moderate/index.js
+++ b/src/routes/moderate/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Requests from './components/Requests'
 import { Loading } from '../../components/loading'
 import useJoinedSpaces from '../../components/matrix_joined_spaces'
@@ -15,10 +15,10 @@ import TextNavigation from '../../components/medienhausUI/textNavigation'
 import Invites from '../../components/Invites'
 import Matrix from '../../Matrix'
 import findValueDeep from 'deepdash/findValueDeep'
-import * as _ from 'lodash'
 import { fetchId } from '../../helpers/MedienhausApiHelper'
 
 import styled from 'styled-components'
+import { createMatrixStructureObject } from '../../helpers/createMatrixStructureObject'
 
 const TabSection = styled.section`
   display: grid;
@@ -44,61 +44,6 @@ const Moderate = () => {
 
   const { t } = useTranslation('moderate')
 
-  const createStructureObject = useCallback(async () => {
-    async function getSpaceStructure (matrixClient, motherSpaceRoomId, includeRooms) {
-      const result = {}
-
-      function createSpaceObject (id, name, metaEvent, topic) {
-        return {
-          id: id,
-          name: name,
-          type: metaEvent.content.type,
-          topic: topic,
-          children: {}
-        }
-      }
-
-      async function scanForAndAddSpaceChildren (spaceId, path) {
-        if (spaceId === 'undefined') return
-        const stateEvents = await matrixClient.roomState(spaceId).catch(console.log)
-        // check if room exists in roomHierarchy
-        // const existsInCurrentTree = _.find(hierarchy, {room_id: spaceId})
-        // const metaEvent = await matrixClient.getStateEvent(spaceId, 'dev.medienhaus.meta')
-        const metaEvent = _.find(stateEvents, { type: 'dev.medienhaus.meta' })
-        if (!metaEvent) return
-        // if (!typesOfSpaces.includes(metaEvent.content.type)) return
-
-        const nameEvent = _.find(stateEvents, { type: 'm.room.name' })
-        if (!nameEvent) return
-        const spaceName = nameEvent.content.name
-        let topic = _.find(stateEvents, { type: 'm.room.topic' })
-        if (topic) topic = topic.content.topic
-        // if (initial) {
-        // result.push(createSpaceObject(spaceId, spaceName, metaEvent))
-        _.set(result, [...path, spaceId], createSpaceObject(spaceId, spaceName, metaEvent, topic))
-        // }
-
-        // const spaceSummary = await matrixClient.getSpaceSummary(spaceId)
-        if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') console.log(`getting children for ${spaceId} / ${spaceName}`)
-        for (const event of stateEvents) {
-          if (event.type !== 'm.space.child' && !includeRooms) continue
-          if (event.type === 'm.space.child' && _.size(event.content) === 0) continue // check to see if body of content is empty, therefore space has been removed
-          if (event.room_id !== spaceId) continue
-
-          await scanForAndAddSpaceChildren(event.state_key, [...path, spaceId, 'children'])
-          // }
-        }
-      }
-
-      await scanForAndAddSpaceChildren(motherSpaceRoomId, [])
-      return result
-    }
-
-    if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') console.log('---- started structure ----')
-    const tree = await getSpaceStructure(matrixClient, localStorage.getItem(process.env.REACT_APP_APP_NAME + '_root_context_space'), false)
-    return tree
-  }, [matrixClient])
-
   useEffect(() => {
     const controller = new AbortController()
 
@@ -108,7 +53,7 @@ const Moderate = () => {
       let tree = {}
 
       // with no api we have to create the structure ourselves
-      if (!config.medienhaus.api) tree = await createStructureObject()
+      if (!config.medienhaus.api) tree = await createMatrixStructureObject(localStorage.getItem(process.env.REACT_APP_APP_NAME + '_root_context_space'))
       for (const space of joinedSpaces) {
         if (space.meta.type !== 'context') continue
         if (space.powerLevel < 50) continue
@@ -123,7 +68,7 @@ const Moderate = () => {
           space.authors = room.origin.authors
         } else {
           const contextObject = findValueDeep(
-            tree,
+            tree[0],
             (value, key, parent) => {
               if (value.id === space.room_id) return true
             }, { childrenPath: 'children', includeRoot: false, rootIsChildren: true })
@@ -148,7 +93,6 @@ const Moderate = () => {
           }
         })
       }
-      console.log(rooms)
       setModerationRooms(rooms)
       setLoading(false)
     }
@@ -159,7 +103,7 @@ const Moderate = () => {
     return () => {
       controller && controller.abort()
     }
-  }, [createStructureObject, joinedSpaces])
+  }, [joinedSpaces, matrixClient])
 
   useEffect(() => {
     let cancelled = false
@@ -387,7 +331,7 @@ const Moderate = () => {
 
       {moderationRooms && Object.keys(moderationRooms).length > 0 && <>
         <TabSection>
-          {Object.keys(config?.medienhaus?.sites?.moderate).map((value, index) => {
+          {Object.keys(config?.medienhaus?.sites?.moderate).map((value) => {
             return <TextNavigation width="auto" disabled={value === selection} active={value === selection} value={value} key={value} onClick={(e) => setSelection(e.target.value)}>{value.replace(/([a-z0-9])([A-Z])/g, '$1 $2')}</TextNavigation>
           })}
         </TabSection>


### PR DESCRIPTION
## Description

This PR refactors the `createStructureObject` function to make reusable. 

An optional `setContexts` parameter has been added. If this parameter is provided, the function will update the contexts array when a child space is found. If not, it will ignore this step. This could be further improved and shouldn't really happen inside the function. 

The consumer of the function is now responsible for handling the loading state before and after the call.

## Testing

_please test if you can still select contents in /create and if /moderate is working normally for you_
