### PR TITLE
feat: config flag for max entries per user

### DIFF
--- a/src/assets/locales/de/content.json
+++ b/src/assets/locales/de/content.json
@@ -74,5 +74,6 @@
   "Date and Venue": "Datum und Veranstaltungsort",
   "SAVE CHANGES": "ÄNDERUNGEN SPEICHERN",
   "select language": "Sprache auswählen",
-  "Add": "Hinzufügen"
+  "Add": "Hinzufügen",
+  "You already reached the maximum amount of created entries. Remove some to create additional ones.": "Sie haben bereits die maximale Anzahl an erstellten Einträgen erreicht. Löschen Sie einige, um zusätzliche erstellen zu können."
 }

--- a/src/assets/locales/de/content.json
+++ b/src/assets/locales/de/content.json
@@ -75,5 +75,5 @@
   "SAVE CHANGES": "ÄNDERUNGEN SPEICHERN",
   "select language": "Sprache auswählen",
   "Add": "Hinzufügen",
-  "You already reached the maximum amount of created entries. Remove some to create additional ones.": "Sie haben bereits die maximale Anzahl an erstellten Einträgen erreicht. Löschen Sie einige, um zusätzliche erstellen zu können."
+  "You’ve reached the maximum amount of entries.": "Sie haben bereits die maximale Anzahl an Einträgen erreicht."
 }

--- a/src/components/nav/index.js
+++ b/src/components/nav/index.js
@@ -7,6 +7,7 @@ import useJoinedSpaces from '../matrix_joined_spaces'
 import Matrix from '../../Matrix'
 import config from '../../config.json'
 import { fetchId } from '../../helpers/MedienhausApiHelper'
+import { sortBy } from 'lodash'
 
 const Nav = () => {
   const auth = useAuth()
@@ -19,6 +20,21 @@ const Nav = () => {
   const [contextInvites, setContextInvites] = useState([])
   const { joinedSpaces, reload } = useJoinedSpaces(false)
   const matrixClient = Matrix.getMatrixClient()
+  const [projects, setProjects] = useState({})
+
+  useEffect(() => {
+    let cancelled = false
+    if (joinedSpaces && !cancelled) {
+      const item = config.medienhaus?.item ? Object.keys(config.medienhaus?.item).concat('item') : ['item']
+      const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type))
+      setProjects(sortBy(updatedProjects, 'name'))
+    }
+
+    return () => {
+      cancelled = true
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [joinedSpaces])
 
   useEffect(() => {
     let cancelled = false
@@ -177,7 +193,7 @@ const Nav = () => {
           {auth.user && (
             <>
               <div>
-                <NavLink to="/create">/create</NavLink>
+                <NavLink className={(typeof config.medienhaus?.maxEntriesPerUser === 'number' && projects.length >= config.medienhaus?.maxEntriesPerUser) ? 'disabled' : ''} to="/create">/create</NavLink>
                 <NavLink to="/content">/content <sup className={`notification ${itemInvites.length > 0 ? '' : 'hidden'}`}>●</sup></NavLink>
               </div>
               <div>

--- a/src/config.extended.example.json
+++ b/src/config.extended.example.json
@@ -87,6 +87,7 @@
       "lat": 0.0,
       "lng": 0.0
     },
+    "maxProjectsReached":10,
     "allowSelectingRootContext": true,
     "api": "https://api.dev.medienhaus.udk-berlin.de/api/v2/",
     "customServer": true

--- a/src/config.extended.example.json
+++ b/src/config.extended.example.json
@@ -87,7 +87,7 @@
       "lat": 0.0,
       "lng": 0.0
     },
-    "maxProjectsReached":10,
+    "maxEntriesPerUser": 10,
     "allowSelectingRootContext": true,
     "api": "https://api.dev.medienhaus.udk-berlin.de/api/v2/",
     "customServer": true

--- a/src/routes/create/ProjectTitle/index.js
+++ b/src/routes/create/ProjectTitle/index.js
@@ -168,7 +168,7 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
         <div className={!newProject ? 'confirmation' : null}>
           {!newProject && <button className="cancel" onClick={(e) => { e.preventDefault(); setEdit(false); setProjectTitle(oldTitle) }}>{t('CANCEL')}</button>}
           {!title && newProject && <LoadingSpinnerButton disabled={!projectTitle || projectTitle.length > 100 || maxProjectsReached} onClick={onClickCreateNewProject}>{t('Create')}</LoadingSpinnerButton>}
-          {maxProjectsReached && <p>{t('You already reached the maximum amount of created entries. Remove some to create additional ones.')}</p>}
+          {maxProjectsReached && <p style={{ marginTop: 'var(--margin)' }}>❗️ {t('You’ve reached the maximum amount of entries.')}</p>}
           {title && edit && (projectTitle !== oldTitle) &&
             <LoadingSpinnerButton
               className="confirm" disabled={projectTitle.length > 100} onClick={async () => {

--- a/src/routes/create/ProjectTitle/index.js
+++ b/src/routes/create/ProjectTitle/index.js
@@ -30,12 +30,6 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
       const item = config.medienhaus?.item ? Object.keys(config.medienhaus?.item).concat('item') : ['item']
       const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type))
       setProjects(_.sortBy(updatedProjects, 'name'))
-
-      if ((typeof config.medienhaus?.maxEntriesPerUser === 'number') && (projects.length >= config.medienhaus?.maxEntriesPerUser)) {
-        setMaxProjectsReached(true)
-      } else {
-        setMaxProjectsReached(false)
-      }
     }
 
     return () => {
@@ -44,6 +38,14 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [joinedSpaces])
+
+  useEffect(() => {
+    if ((typeof config.medienhaus?.maxEntriesPerUser === 'number') && (projects.length >= config.medienhaus?.maxEntriesPerUser)) {
+      setMaxProjectsReached(true)
+    } else {
+      setMaxProjectsReached(false)
+    }
+  }, [projects])
 
   useEffect(() => {
     setProjectTitle(title)

--- a/src/routes/create/ProjectTitle/index.js
+++ b/src/routes/create/ProjectTitle/index.js
@@ -8,6 +8,8 @@ import { useTranslation } from 'react-i18next'
 import config from '../../../config.json'
 import _ from 'lodash'
 
+import useJoinedSpaces from '../../../components/matrix_joined_spaces'
+
 const ProjectTitle = ({ title, projectSpace, template, callback }) => {
   const { t } = useTranslation('content')
   const [projectTitle, setProjectTitle] = useState('')
@@ -17,6 +19,31 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
   const [loading, setLoading] = useState(false)
   const matrixClient = Matrix.getMatrixClient()
   const history = useHistory()
+
+  const { joinedSpaces } = useJoinedSpaces(false)
+  const [projects, setProjects] = useState({})
+  const [maxProjectsReached, setMaxProjectsReached] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    if (joinedSpaces && !cancelled) {
+      const item = config.medienhaus?.item ? Object.keys(config.medienhaus?.item).concat('item') : ['item']
+      const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type))
+      setProjects(_.sortBy(updatedProjects, 'name'))
+
+      if ((typeof config.medienhaus?.maxEntriesPerUser === 'number') && (projects.length >= config.medienhaus?.maxEntriesPerUser)) {
+        setMaxProjectsReached(true)
+      } else {
+        setMaxProjectsReached(false)
+      }
+    }
+
+    return () => {
+      cancelled = true
+    }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [joinedSpaces])
 
   useEffect(() => {
     setProjectTitle(title)
@@ -138,8 +165,8 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
       : edit && (projectTitle !== oldTitle) &&
         <div className={!newProject ? 'confirmation' : null}>
           {!newProject && <button className="cancel" onClick={(e) => { e.preventDefault(); setEdit(false); setProjectTitle(oldTitle) }}>{t('CANCEL')}</button>}
-          {!title && newProject && <LoadingSpinnerButton disabled={!projectTitle || projectTitle.length > 100} onClick={onClickCreateNewProject}>{t('Create')}</LoadingSpinnerButton>}
-
+          {!title && newProject && <LoadingSpinnerButton disabled={!projectTitle || projectTitle.length > 100 || maxProjectsReached} onClick={onClickCreateNewProject}>{t('Create')}</LoadingSpinnerButton>}
+          {maxProjectsReached && <p>{t('You already reached the maximum amount of created entries. Remove some to create additional ones.')}</p>}
           {title && edit && (projectTitle !== oldTitle) &&
             <LoadingSpinnerButton
               className="confirm" disabled={projectTitle.length > 100} onClick={async () => {


### PR DESCRIPTION
this PR introduces the optional config flag "maxEntriesPerUser", which blocks the creation of more than the given limit. This flag is optional so if it is not defined, no limit is given as before. When the limit is reached it disables the `/create` navigation link as well as the create button on that given route