### PR TITLE
feat: count `maxEntriesPerUser` via application name meta event

### DIFF
--- a/src/components/nav/index.js
+++ b/src/components/nav/index.js
@@ -26,7 +26,7 @@ const Nav = () => {
     let cancelled = false
     if (joinedSpaces && !cancelled) {
       const item = config.medienhaus?.item ? Object.keys(config.medienhaus?.item).concat('item') : ['item']
-      const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type))
+      const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type) && space.meta.application === process.env.REACT_APP_APP_NAME)
       setProjects(sortBy(updatedProjects, 'name'))
     }
 

--- a/src/routes/create/ProjectTitle/index.js
+++ b/src/routes/create/ProjectTitle/index.js
@@ -27,7 +27,6 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
   useEffect(() => {
     let cancelled = false
     if (joinedSpaces && !cancelled) {
-      console.log('joinedSpaces', joinedSpaces)
       const item = config.medienhaus?.item ? Object.keys(config.medienhaus?.item).concat('item') : ['item']
       const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type) && space.meta.application === process.env.REACT_APP_APP_NAME)
       setProjects(_.sortBy(updatedProjects, 'name'))

--- a/src/routes/create/ProjectTitle/index.js
+++ b/src/routes/create/ProjectTitle/index.js
@@ -27,8 +27,9 @@ const ProjectTitle = ({ title, projectSpace, template, callback }) => {
   useEffect(() => {
     let cancelled = false
     if (joinedSpaces && !cancelled) {
+      console.log('joinedSpaces', joinedSpaces)
       const item = config.medienhaus?.item ? Object.keys(config.medienhaus?.item).concat('item') : ['item']
-      const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type))
+      const updatedProjects = joinedSpaces?.filter(space => !space.meta?.deleted && item.includes(space.meta.type) && space.meta.application === process.env.REACT_APP_APP_NAME)
       setProjects(_.sortBy(updatedProjects, 'name'))
     }
 


### PR DESCRIPTION
Two liner PR which checks for the application name stored in the `dev.medienhaus.meta` event. only if the application name is equal with the current interface, those entries will be counted for the `maxEntriesPerUser`